### PR TITLE
Add curated projects index page to fix /projects 404

### DIFF
--- a/newsletter.md
+++ b/newsletter.md
@@ -2,4 +2,8 @@
 title: Newsletter
 ---
 
-The newsletter is currently on hold. Check back soon, or in the meantime see [Writings](/writings) or [Now](/now) for the latest on what I'm working on.
+I have a kind-of newsletter on Substack but it is infrequently updated and it will soon move here and get more active:
+
+https://rufuspollock.substack.com/
+
+In the meantime see [Writings](/writings) or [Now](/now) for the latest on what I'm working on.

--- a/newsletter.md
+++ b/newsletter.md
@@ -1,0 +1,5 @@
+---
+title: Newsletter
+---
+
+The newsletter is currently on hold. Check back soon, or in the meantime see [Writings](/writings) or [Now](/now) for the latest on what I'm working on.

--- a/projects/index.md
+++ b/projects/index.md
@@ -1,0 +1,15 @@
+---
+title: Projects
+description: Things I'm working on or have worked on
+---
+
+* [FlowerShow](/projects/FlowerShow)
+* [comparethe](/projects/comparethe)
+* [Life Itself](/projects/Life%20Itself)
+* [Life Itself Hubs](/projects/Life%20Itself%20Hubs)
+* [Life Itself Practicum](/projects/Life%20Itself%20Practicum)
+* [Over the Mountains](/projects/Over%20the%20Mountains)
+* [AI Tried Today](/projects/AI%20Tried%20Today)
+* [Collective Action Course](/projects/Collective%20Action%20Course)
+* [TaskGraph](/projects/TaskGraph)
+* [DataHub.io](/projects/DataHub.io)

--- a/tao/index.md
+++ b/tao/index.md
@@ -1,6 +1,6 @@
 # Tao of Rufus
 
-This is [Rufus Pollock's](https://rufuspollock) tao, or "way".
+This is [Rufus Pollock's](https://rufuspollock.com) tao, or "way".
 
 It is my guide to how to live and how to "get stuff done". It ranges from the very high level like setting life goals to the low level like planning projects and tracking time.
 


### PR DESCRIPTION
## Summary
- Adds `projects/index.md` listing the existing project pages under `/projects`, fixing the current 404 on that route.

## Test plan
- [ ] Confirm `/projects` renders the list correctly
- [ ] Verify each linked project page resolves