### PR TITLE
Add Roadmap page and nav link

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,6 +26,10 @@
         "name": "Tao"
       },
       {
+        "href": "/roadmap",
+        "name": "Roadmap"
+      },
+      {
         "href": "/writings",
         "name": "Writings"
       },

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,22 @@
+---
+title: Roadmap
+---
+
+## Roadmap for the Tao
+
+1. [Index](https://rufuspollock.com/tao): why the Tao exists and how to read it.
+2. [Getting Stuff Done](https://tao.lifeitself.org/handbook/getting-stuff-done) and [Key Views](https://tao.lifeitself.org/views): orientation before the rest.
+3. [Five Levels of Agency](https://rufuspollock.com/tao/Five%20levels%20of%20agency): how to act.
+4. [Hypotheses](https://rufuspollock.com/tao/Hypotheses) + [Open-Minded Rigour](https://tao.lifeitself.org/principles#open-minded-rigour): how to question.
+5. The project system: [Project Phase and Status](https://rufuspollock.com/tao/Project%20Phase%20and%20Status), [Job Stories](https://rufuspollock.com/tao/Job%20Stories), [Issues](https://rufuspollock.com/tao/Issues).
+6. Recurring: [Standups](https://rufuspollock.com/tao/Standups), [Meetings](https://rufuspollock.com/tao/Meetings).
+
+## From Life Itself Dao
+
+Worth pulling into the personal Tao:
+
+1. [Getting Stuff Done](https://tao.lifeitself.org/principles) + [Key Views](https://tao.lifeitself.org/views).
+2. [Open-Minded Rigour](https://tao.lifeitself.org/principles): pairs with [Hypotheses](https://rufuspollock.com/tao/Hypotheses).
+3. [Experimentation and Creativity](https://tao.lifeitself.org/principles#experimentation-and-creativity).
+4. [Zen & Mindfulness](https://tao.lifeitself.org/principles#zen--mindfulness).
+</content>


### PR DESCRIPTION
## Summary
- Adds a new "Roadmap" tab to the site nav, linked to `/roadmap`
- Adds `roadmap.md` with a suggested reading order for the Tao, plus items worth pulling in from the Life Itself Dao (principles, views)

## Test plan
- [ ] Confirm `/roadmap` renders correctly after deploy
- [ ] Confirm nav shows "Roadmap" between "Tao" and "Writings"